### PR TITLE
Migrate to Bitget API V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.bak
 api-keys.txt
 test-data/
+.claude/settings.local.json
+CLAUDE.md

--- a/API-SPEC.md
+++ b/API-SPEC.md
@@ -1,4 +1,4 @@
-# Bitget API Specification
+# Bitget API V2 Specification
 
 ## Base URLs
 - Primary: https://api.bitget.com
@@ -23,61 +23,76 @@ message = timestamp + method + request_path + query_string + body
 Where:
 - `timestamp`: Same as ACCESS-TIMESTAMP header
 - `method`: HTTP method in uppercase (GET, POST, etc.)
-- `request_path`: Path without domain (e.g., `/api/spot/v1/account/assets`)
+- `request_path`: Path without domain (e.g., `/api/v2/spot/account/assets`)
 - `query_string`: Query parameters (without ?)
 - `body`: Request body (empty string for GET requests)
 
 ## Key Endpoints
 
+### Public
+
+#### Server Time
+```
+GET /api/v2/public/time
+```
+
+Response:
+- `serverTime`: Current server timestamp
+
 ### Spot Trading
 
 #### Account Balance
 ```
-GET /api/spot/v1/account/assets
+GET /api/v2/spot/account/assets
 ```
 
 Optional Parameters:
 - `coin`: Filter by specific coin (e.g., "BTC")
 
 Response includes:
+- `coin`: Coin name
 - `available`: Available balance
 - `frozen`: Frozen balance
 - `locked`: Locked balance
 
-#### Account Balance (Lite)
+#### Market Tickers
 ```
-GET /api/spot/v1/account/assets-lite
+GET /api/v2/spot/market/tickers
 ```
 
-Similar to assets endpoint but defaults to showing only non-zero balances.
+Optional Parameters:
+- `symbol`: Trading pair (e.g., "BTCUSDT")
+
+Response includes:
+- `symbol`: Trading pair
+- `lastPr`: Last price
+- `high24h`: 24h high
+- `low24h`: 24h low
+- `change24h`: 24h change percentage
 
 ### Futures Trading (Mix)
 
 #### Account Information
 ```
-GET /api/mix/v1/account/account
-GET /api/mix/v1/account/accounts
+GET /api/v2/mix/account/accounts
 ```
 
 Parameters:
-- `symbol`: Trading pair (e.g., "BTCUSDT_UMCBL")
-- `marginCoin`: Margin coin (e.g., "USDT")
+- `productType`: Product type (USDT-FUTURES, COIN-FUTURES, USDC-FUTURES)
 
 #### Open Positions
 ```
-GET /api/mix/v1/position/allPosition
-GET /api/mix/v1/position/allPosition-v2
+GET /api/v2/mix/position/all-position
 ```
 
 Parameters:
-- `productType`: Product type (umcbl, dmcbl, cmcbl, sumcbl)
+- `productType`: Product type (USDT-FUTURES, COIN-FUTURES, USDC-FUTURES)
 - `marginCoin`: Optional filter
 
 Response includes:
 - `symbol`: Trading pair
 - `marginCoin`: Margin currency
 - `holdSide`: Position side (long/short)
-- `openDelegateCount`: Number of open orders
 - `margin`: Position margin
 - `available`: Available quantity
 - `locked`: Locked quantity
@@ -85,17 +100,27 @@ Response includes:
 - `leverage`: Leverage ratio
 - `achievedProfits`: Realized PnL
 - `unrealizedPL`: Unrealized PnL
-- `unrealizedPLR`: Unrealized PnL ratio
 - `liquidationPrice`: Liquidation price
-- `keepMarginRate`: Maintenance margin rate
 - `markPrice`: Mark price
+- `marketPrice`: Market price
 - `averageOpenPrice`: Average entry price
 
+#### Market Ticker
+```
+GET /api/v2/mix/market/ticker
+```
+
+Parameters:
+- `symbol`: Trading pair
+- `productType`: Product type
+
+Response includes:
+- `lastPr`: Last price
+
 #### Product Types
-- `umcbl`: USDT perpetual
-- `dmcbl`: Universal margin
-- `cmcbl`: USDC perpetual
-- `sumcbl`: USDT perpetual demo
+- `USDT-FUTURES`: USDT perpetual
+- `COIN-FUTURES`: Coin margined perpetual
+- `USDC-FUTURES`: USDC perpetual
 
 ## Rate Limits
 - Most endpoints: 10-20 requests/second
@@ -104,12 +129,13 @@ Response includes:
 
 ## Response Format
 Standard JSON response with:
-- `code`: Error code (0 for success)
+- `code`: Error code ("00000" for success)
 - `msg`: Error message
-- `data`: Response data
+- `requestTime`: Request timestamp
+- `data`: Response data (often an array in V2)
 
 ## Error Codes
-- 0: Success
+- "00000": Success
 - 429: Rate limit exceeded
 - Various other codes for authentication failures, invalid parameters, etc.
 

--- a/Bitget.lua
+++ b/Bitget.lua
@@ -25,7 +25,7 @@
 -- SOFTWARE.
 
 WebBanking{
-    version = 1.1,
+    version = 2.0,
     country = "de",
     description = string.format(MM.localizeText("Fetch balances and positions from %s"), "Bitget"),
     services = {"Bitget"},
@@ -231,10 +231,10 @@ function lookupCoinName(symbol)
 end
 
 function fetchCurrentPrice(symbol)
-    local response = makeRequest("GET", "/api/mix/v1/market/ticker", {symbol = symbol}, nil)
+    local response = makeRequest("GET", "/api/v2/mix/market/ticker", {symbol = symbol}, nil)
 
-    if response and response.code == "00000" and response.data then
-        return tonumber(response.data.last) or tonumber(response.data.close) or 0
+    if response and response.code == "00000" and response.data and response.data[1] then
+        return tonumber(response.data[1].lastPr) or 0
     end
 
     MM.printStatus("Fallback: Kein aktueller Preis für " .. symbol)
@@ -319,7 +319,7 @@ function InitializeSession(protocol, bankCode, username, username2, password, us
     connection = Connection()
 
     -- Test connection with a simple API call
-    local response = makeRequest("GET", "/api/spot/v1/public/time", nil, nil)
+    local response = makeRequest("GET", "/api/v2/public/time", nil, nil)
 
     if not response or response.code ~= "00000" then
         MM.printStatus("Fehler: Verbindung fehlgeschlagen")
@@ -372,7 +372,7 @@ end
 function fetchSpotBalances()
     local securities = {}
 
-    local response = makeRequest("GET", "/api/spot/v1/account/assets", nil, nil)
+    local response = makeRequest("GET", "/api/v2/spot/account/assets", nil, nil)
 
     if not response or response.code ~= "00000" then
         MM.printStatus("Fehler beim Abrufen der Spot-Guthaben")
@@ -380,7 +380,7 @@ function fetchSpotBalances()
     end
 
     for _, asset in ipairs(response.data or {}) do
-        local coin = asset.coinName or asset.coinDisplayName
+        local coin = asset.coin or asset.coinName or asset.coinDisplayName
         if not coin then
             -- Skip asset if no coin name available
             MM.printStatus("Überspringe Asset ohne Coin-Name")
@@ -412,10 +412,10 @@ function fetchSpotBalances()
                 fiat = true
             else
                 -- For other cryptocurrencies, fetch the current price
-                local priceResponse = makeRequest("GET", "/api/spot/v1/market/ticker", {symbol = coin .. "USDT_SPBL"}, nil)
+                local priceResponse = makeRequest("GET", "/api/v2/spot/market/tickers", {symbol = coin .. "USDT"}, nil)
 
-                if priceResponse and priceResponse.code == "00000" and priceResponse.data then
-                    priceUSD = tonumber(priceResponse.data.close) or 0
+                if priceResponse and priceResponse.code == "00000" and priceResponse.data and priceResponse.data[1] then
+                    priceUSD = tonumber(priceResponse.data[1].lastPr) or 0
                 end
             end
 
@@ -465,7 +465,7 @@ function fetchFuturesPositions()
     local securities = {}
 
     -- First, fetch futures account balance (available funds)
-    local balanceResponse = makeRequest("GET", "/api/mix/v1/account/accounts", {productType = "umcbl"}, nil)
+    local balanceResponse = makeRequest("GET", "/api/v2/mix/account/accounts", {productType = "USDT-FUTURES"}, nil)
     if balanceResponse and balanceResponse.code == "00000" and balanceResponse.data then
         for _, account in ipairs(balanceResponse.data or {}) do
             -- Try different fields for available balance
@@ -487,10 +487,10 @@ function fetchFuturesPositions()
     end
 
     -- Fetch all futures positions
-    local productTypes = {"umcbl", "dmcbl", "cmcbl"} -- USDT, Universal, USDC perpetuals
+    local productTypes = {"USDT-FUTURES", "COIN-FUTURES", "USDC-FUTURES"}
 
     for _, productType in ipairs(productTypes) do
-        local response = makeRequest("GET", "/api/mix/v1/position/allPosition-v2", {productType = productType}, nil)
+        local response = makeRequest("GET", "/api/v2/mix/position/all-position", {productType = productType}, nil)
 
         if response and response.code == "00000" and response.data then
             for _, position in ipairs(response.data or {}) do
@@ -598,5 +598,3 @@ end
 function EndSession()
     -- Nothing to do
 end
-
--- SIGNATURE: MCwCFAvxxJEQqJ7YyXm49LDgsQ47T8C9AhRnIid+ufF7YqV3IF55wkhXbuY7nA==


### PR DESCRIPTION
## Summary
- Bitget deprecated API V1, causing "Bad Request" errors
- Migrated all endpoints to API V2 format
- Updated productTypes from `umcbl/dmcbl/cmcbl` to `USDT-FUTURES/COIN-FUTURES/USDC-FUTURES`
- Adapted response parsing for V2 structure (data arrays, `lastPr` instead of `close`)
- Updated API-SPEC.md documentation

## Test plan
- [x] Tested spot account balance fetching
- [x] Verified cryptocurrency prices are retrieved correctly
- [x] Test futures positions (if available)

🤖 Generated with [Claude Code](https://claude.ai/code)